### PR TITLE
Set dark mode as default for new users

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -25,7 +25,7 @@
   <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg">
 </head>
 
-<body x-data="{ dark: JSON.parse(localStorage.getItem('darkMode') || 'false') }"
+<body x-data="{ dark: JSON.parse(localStorage.getItem('darkMode') || 'true') }"
       x-init="$watch('dark', v => localStorage.setItem('darkMode', v))"
       :class="{ dark }">
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -128,7 +128,7 @@
   function getAppState () {
     return {
       // reactive state
-      dark      : JSON.parse(localStorage.getItem('darkMode') || 'false'),
+      dark      : JSON.parse(localStorage.getItem('darkMode') || 'true'),
       mood      : {{ mood or 3 }},
       moodSaved : false,
       showModal : false,

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -24,7 +24,7 @@
   <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg">
 </head>
 
-<body x-data="{ dark: JSON.parse(localStorage.getItem('darkMode') || 'false') }"
+<body x-data="{ dark: JSON.parse(localStorage.getItem('darkMode') || 'true') }"
       x-init="$watch('dark', v => localStorage.setItem('darkMode', v))"
       :class="{ dark }">
 


### PR DESCRIPTION
## Summary
- default to dark theme if no preference stored in localStorage

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866fbd60c98832dad7a1d98198b085b