### PR TITLE
Add base template and simplify pages

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,40 +1,12 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>📊 Analytics – habit-track</title>
+{% extends "base.html" %}
 
-  <!-- JS -->
+{% block title %}📊 Analytics – habit-track{% endblock %}
+
+{% block head_scripts %}
   <script src="{{ url_for('static', filename='chart.min.js') }}"></script>
-  <script src="{{ url_for('static', filename='alpine.min.js') }}" defer></script>
+{% endblock %}
 
-  <!-- CSS -->
-  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-
-  {% if config.PWA_ENABLED %}
-    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
-    <script>
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register(
-          "{{ url_for('static', filename='service-worker.js') }}"
-        );
-      }
-    </script>
-  {% endif %}
-
-  <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg">
-</head>
-
-<body x-data="{ dark: JSON.parse(localStorage.getItem('darkMode') || 'true') }"
-      x-init="$watch('dark', v => localStorage.setItem('darkMode', v))"
-      :class="{ dark }">
-
-  {% if debug %}
-  <div class="debug-banner">
-    DEBUG MODE ON | Dark: <span x-text="dark"></span> | PWA: {{ config.PWA_ENABLED }}
-  </div>
-  {% endif %}
-
+{% block content %}
   <header>
     <h1>📈 Analytics</h1>
     <div class="controls">
@@ -109,5 +81,4 @@
       </script>
     </div>
   </section>
-</body>
-</html>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}habit-track{% endblock %}</title>
+
+  <!-- JS -->
+  {% block head_scripts %}{% endblock %}
+  <script src="{{ url_for('static', filename='alpine.min.js') }}" defer></script>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+
+  {% if config.PWA_ENABLED and 'github.dev' not in request.host %}
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register(
+          "{{ url_for('static', filename='service-worker.js') }}"
+        );
+      }
+    </script>
+  {% endif %}
+
+  <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg">
+  {% block extra_head %}{% endblock %}
+</head>
+<body {% block body_attrs %}x-data="{ dark: JSON.parse(localStorage.getItem('darkMode') || 'true') }" x-init="$watch('dark', v => localStorage.setItem('darkMode', v))" :class="{ dark }"{% endblock %}>
+{% if debug %}
+  <div class="debug-banner">
+    DEBUG MODE ON | Dark: <span x-text="dark"></span> | PWA: {{ config.PWA_ENABLED }}
+  </div>
+{% endif %}
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,42 +1,18 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>habit-track</title>
+{% extends "base.html" %}
 
-  <!-- JS -->
+{% block title %}habit-track{% endblock %}
+
+{% block head_scripts %}
   <script src="{{ url_for('static', filename='htmx.min.js') }}"></script>
-  <script src="{{ url_for('static', filename='alpine.min.js') }}" defer></script>
+{% endblock %}
 
-  <!-- CSS -->
-  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+{% block extra_head %}
+  <script id="mood-data" type="application/json">{{ mood_stats | tojson }}</script>
+{% endblock %}
 
-  {% if config.PWA_ENABLED and 'github.dev' not in request.host %}
-    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
-    <script>
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register(
-          "{{ url_for('static', filename='service-worker.js') }}"
-        );
-      }
-    </script>
-  {% endif %}
-  <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg">
-</head>
+{% block body_attrs %}x-data="getAppState()" x-init="$watch('dark', v => localStorage.setItem('darkMode', v))" :class="{ dark }"{% endblock %}
 
-<!-- snapshot of mood_stats for Alpine -->
-<script id="mood-data" type="application/json">{{ mood_stats | tojson }}</script>
-
-<body x-data="getAppState()"
-      x-init="$watch('dark', v => localStorage.setItem('darkMode', v))"
-      :class="{ dark }">
-
-{% if debug %}
-  <div class="debug-banner">
-    DEBUG MODE ON | Dark: <span x-text="dark"></span> | PWA: {{ config.PWA_ENABLED }}
-  </div>
-{% endif %}
-
+{% block content %}
 <header>
   <h1>🤖 Habit Tracker</h1>
   <div class="controls">
@@ -162,5 +138,4 @@
     document.body.__x.$data.showToast(`Save failed (${code})`, true);
   });
 </script>
-</body>
-</html>
+{% endblock %}

--- a/templates/journal_history.html
+++ b/templates/journal_history.html
@@ -1,27 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>📜 Journal History – habit-track</title>
+{% extends "base.html" %}
 
-  <!-- CSS -->
-  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+{% block title %}📜 Journal History – habit-track{% endblock %}
 
-  {% if config.PWA_ENABLED and 'github.dev' not in request.host %}
-    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
-    <script>
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register(
-          "{{ url_for('static', filename='service-worker.js') }}"
-        );
-      }
-    </script>
-  {% endif %}
-
-  <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg">
-</head>
-
-<body>
+{% block content %}
   <header>
     <h1>📜 Journal History</h1>
     <p><a href="/" class="button">← Back to Dashboard</a></p>
@@ -37,5 +18,4 @@
   {% else %}
     <p>No entries found.</p>
   {% endif %}
-</body>
-</html>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,33 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>⚙️ Settings – habit-track</title>
+{% extends "base.html" %}
 
-  <!-- JS -->
-  <script src="{{ url_for('static', filename='alpine.min.js') }}" defer></script>
+{% block title %}⚙️ Settings – habit-track{% endblock %}
 
-  <!-- CSS -->
-  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-
-  {% if config.PWA_ENABLED and 'github.dev' not in request.host %}
-    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
-    <script>
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register(
-          "{{ url_for('static', filename='service-worker.js') }}"
-        );
-      }
-    </script>
-  {% endif %}
-
-  <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg">
-</head>
-
-<body x-data="{ dark: JSON.parse(localStorage.getItem('darkMode') || 'true') }"
-      x-init="$watch('dark', v => localStorage.setItem('darkMode', v))"
-      :class="{ dark }">
-
+{% block content %}
   <header>
     <h1>⚙️ Settings</h1>
     <div class="controls">
@@ -72,5 +47,4 @@
 
     <button type="submit" class="button">💾 Save Settings</button>
   </form>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- centralize `<head>` and Alpine dark-mode init in a new `base.html`
- extend the base template from all pages
- clean up duplicate body attributes and PWA scripts

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f4846fb4832da7084fb332ed5b7f