### PR TITLE
Improve log validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,10 +207,18 @@ def index():
 
 @app.post("/log")
 def log_habit():
-    habit = request.form["habit"]
-    duration = int(request.form["duration"])
+    habit = request.form.get("habit")
+    duration_str = request.form.get("duration")
     note = request.form.get("note", "").strip()
-    target_date = request.form["date"]
+    target_date = request.form.get("date")
+
+    if not habit or not duration_str or not target_date:
+        return {"error": "Missing habit, duration, or date"}, 400
+
+    if not str(duration_str).isdigit():
+        return {"error": "Duration must be a number"}, 400
+
+    duration = int(duration_str)
 
     backend = get_storage_backend()
     if request.args.get("delete") == "1":

--- a/tests/test_log_route.py
+++ b/tests/test_log_route.py
@@ -20,3 +20,41 @@ def test_log_save(tmp_path):
     finally:
         app.DATA_FILE = orig_data
         app.CONFIG_FILE = orig_config
+
+
+def test_log_missing_duration(tmp_path):
+    orig_data = app.DATA_FILE
+    orig_config = app.CONFIG_FILE
+    app.DATA_FILE = tmp_path / "data.json"
+    app.CONFIG_FILE = tmp_path / "config.json"
+    client = app.app.test_client()
+    try:
+        rv = client.post(
+            '/log',
+            data={'habit': 'Meditation', 'note': 'fail', 'date': '2030-01-01'},
+        )
+        assert rv.status_code == 400
+    finally:
+        app.DATA_FILE = orig_data
+        app.CONFIG_FILE = orig_config
+
+
+def test_log_invalid_duration(tmp_path):
+    orig_data = app.DATA_FILE
+    orig_config = app.CONFIG_FILE
+    app.DATA_FILE = tmp_path / "data.json"
+    app.CONFIG_FILE = tmp_path / "config.json"
+    client = app.app.test_client()
+    try:
+        rv = client.post(
+            '/log',
+            data={
+                'habit': 'Meditation',
+                'duration': 'abc',
+                'date': '2030-01-01',
+            },
+        )
+        assert rv.status_code == 400
+    finally:
+        app.DATA_FILE = orig_data
+        app.CONFIG_FILE = orig_config


### PR DESCRIPTION
## Summary
- validate required fields for `/log`
- add tests for missing or invalid duration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868100001f4832db125b1b57e09f1a9