### PR TITLE
Fix toast listener error guard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -124,6 +124,7 @@
   <script>
     /* Success toast after habit grid swap */
     htmx.on('htmx:afterSwap', e => {
+      if (!e.detail || !e.detail.target) return;
       if (e.detail.target.id === 'habit-grid') {
         document.body.__x.$data.showToast('Saved ✔️');
       }


### PR DESCRIPTION
## Summary
- guard against missing `detail` in `htmx:afterSwap`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686810001ddc832d9609a00558902bab