### PR TITLE
Refactor APP_MODE handling and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 # ⬇️ Optional: enable AI journal prompts
 export OPENAI_API_KEY=sk-********************************
+# Choose config via APP_MODE (dev | prod)
+export APP_MODE=dev
 
-python app.py   # auto-reload + debug if FLASK_DEBUG=1
+python app.py   # auto-reload in dev mode
 ````
 
 Open [http://localhost:5000](http://localhost:5000) & start tracking.
@@ -81,7 +83,7 @@ npm ci && npx playwright test # E2E smoke
 Start command:
 
 ```bash
-gunicorn app:app --bind 0.0.0.0:$PORT
+APP_MODE=prod gunicorn app:app --bind 0.0.0.0:$PORT
 ```
 
 Need one-click? See `/docs/deploy-render.md`.

--- a/app.py
+++ b/app.py
@@ -7,12 +7,23 @@ import storage
 import openai
 
 app = Flask(__name__)
-app.config.from_object(DevConfig)
 
-# Application mode: 'prod', 'dev', or 'test'.
-APP_MODE = os.getenv("APP_MODE", "prod")
-app.config["APP_MODE"] = APP_MODE
-app.config["PWA_ENABLED"] = APP_MODE == "prod"
+
+def create_app(mode=None):
+    """Configure the global Flask app based on APP_MODE."""
+    if mode is None:
+        mode = os.getenv("APP_MODE", "prod")
+    if mode == "prod":
+        app.config.from_object(ProdConfig)
+    else:
+        app.config.from_object(DevConfig)
+    app.config["APP_MODE"] = mode
+    app.config["PWA_ENABLED"] = mode == "prod"
+    return app
+
+
+# Apply configuration at import so gunicorn sees the correct settings.
+create_app()
 
 DATA_FILE = Path.home() / ".habit_log.json"
 CONFIG_FILE = Path.home() / ".habit_config.json"
@@ -395,14 +406,10 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.mode == "prod":
-        app.config.from_object(ProdConfig)
+    create_app(args.mode)
 
     env_debug = os.getenv("DEBUG", "").lower() in {"1", "true", "yes"}
     debug = args.debug or env_debug or app.config.get("DEBUG", False)
-
-    app.config["APP_MODE"] = args.mode
-    app.config["PWA_ENABLED"] = args.mode == "prod"
 
     port = int(os.environ.get("PORT", 5000))
     app.run(host="0.0.0.0", port=port, debug=debug)

--- a/tests/test_app_mode.py
+++ b/tests/test_app_mode.py
@@ -1,0 +1,12 @@
+def test_app_mode_prod_enables_pwa(monkeypatch):
+    monkeypatch.setenv("APP_MODE", "prod")
+    import importlib
+    import app
+    importlib.reload(app)
+    try:
+        assert app.app.config["PWA_ENABLED"] is True
+        assert app.app.config["APP_MODE"] == "prod"
+    finally:
+        monkeypatch.delenv("APP_MODE", raising=False)
+        importlib.reload(app)
+


### PR DESCRIPTION
## Summary
- refactor `app.py` to use a `create_app` factory
- detect `APP_MODE` during import and configure `ProdConfig` or `DevConfig`
- document `APP_MODE` usage in README
- test that `APP_MODE=prod` enables the PWA

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681001f5bc832da9e8027dd37a3e13