### PR TITLE
Validate mood score input

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,7 +233,15 @@ def log_habit():
 
 @app.route("/mood", methods=["POST"])
 def log_mood():
-    score = int(request.form["score"])
+    score_str = request.form.get("score")
+    if score_str is None:
+        return {"status": "error", "message": "score required"}, 400
+    try:
+        score = int(score_str)
+    except (TypeError, ValueError):
+        return {"status": "error", "message": "invalid score"}, 400
+    if not 1 <= score <= 5:
+        return {"status": "error", "message": "invalid score"}, 400
     backend = get_storage_backend()
     today = str(datetime.date.today())
     backend.save_mood(today, score)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -83,6 +83,24 @@ def test_log_mood(tmp_path):
         restore(orig_data, orig_config)
 
 
+def test_mood_missing_score(tmp_path):
+    client, orig_data, orig_config = make_client(tmp_path)
+    try:
+        res = client.post("/mood", data={})
+        assert res.status_code == 400
+    finally:
+        restore(orig_data, orig_config)
+
+
+def test_mood_out_of_range(tmp_path):
+    client, orig_data, orig_config = make_client(tmp_path)
+    try:
+        res = client.post("/mood", data={"score": "10"})
+        assert res.status_code == 400
+    finally:
+        restore(orig_data, orig_config)
+
+
 def test_homepage(tmp_path):
     client, orig_data, orig_config = make_client(tmp_path)
     try:


### PR DESCRIPTION
## Summary
- validate the `score` value when logging moods
- test invalid mood submissions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686810724778832d928055ded21dc986