### PR TITLE
Fix toast error guard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -131,8 +131,10 @@
 
     /* Error toast for non-200 responses */
     htmx.on('htmx:responseError', e => {
-      const code = e.detail.xhr.status;
-      document.body.__x.$data.showToast(`Save failed (${code})`, true);
+      if (document.body.__x && e.detail) {
+        const code = e.detail.xhr.status;
+        document.body.__x.$data.showToast(`Save failed (${code})`, true);
+      }
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- avoid TypeError in error handler by checking Alpine instance and event detail

## Testing
- `pytest -q`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686810737e18832db0d3273ecc319dab