### PR TITLE
Add tests for mood validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 ~/.habit_config.json
+
+# Habit tracker data directory
+data/

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -101,6 +101,24 @@ def test_mood_out_of_range(tmp_path):
         restore(orig_data, orig_config)
 
 
+def test_mood_invalid_type(tmp_path):
+    client, orig_data, orig_config = make_client(tmp_path)
+    try:
+        res = client.post("/mood", data={"score": "abc"})
+        assert res.status_code == 400
+    finally:
+        restore(orig_data, orig_config)
+
+
+def test_mood_float_value(tmp_path):
+    client, orig_data, orig_config = make_client(tmp_path)
+    try:
+        res = client.post("/mood", data={"score": "3.5"})
+        assert res.status_code == 400
+    finally:
+        restore(orig_data, orig_config)
+
+
 def test_homepage(tmp_path):
     client, orig_data, orig_config = make_client(tmp_path)
     try:


### PR DESCRIPTION
## Summary
- ignore runtime `data/` directory
- add tests ensuring `/mood` rejects non‑numeric scores

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868176cfb84832d91da19c240e3cbcf