### PR TITLE
Enable editing any habit grid cell

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -103,10 +103,12 @@ th, td {
 
 .cell-done {
   background-color: #d0f0d0;
+  position: relative;
 }
 
 .cell-empty {
   background-color: #f4f4f4;
+  position: relative;
 }
 
 body.dark table, body.dark th, body.dark td {
@@ -154,6 +156,26 @@ body.dark .edit-button {
 }
 body.dark .edit-button:hover {
   color: #fff;
+}
+
+/* Small edit icon for all grid cells */
+.cell-edit-icon {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 0.8em;
+  background: none;
+  border: none;
+  color: #888;
+  display: none;
+  cursor: pointer;
+  padding: 0;
+}
+td:hover .cell-edit-icon {
+  display: block;
+}
+body.dark .cell-edit-icon {
+  color: #ccc;
 }
 
 /* Dashboard Tiles */

--- a/templates/_habit_row.html
+++ b/templates/_habit_row.html
@@ -40,7 +40,8 @@
                       label:    '{{ label }}',
                       duration: {{ entry.duration }},
                       note:     `{{ entry.note | e }}`,
-                      date:     '{{ day|string }}'
+                      date:     '{{ day|string }}',
+                      entry_id: '{{ day|string }}_{{ key }}'
                     };
                   "
                   title="Edit entry"
@@ -58,12 +59,12 @@
                     label:    '{{ label }}',
                     duration: parseInt(localStorage.getItem('{{ key }}_duration')) || {{ info.default_duration }},
                     note:     localStorage.getItem('{{ key }}_note') || '',
-                    date:     '{{ day|string }}'
+                    date:     '{{ day|string }}',
+                    entry_id: ''
                   };
                 "
               >Log</button>
             {% endif %}
-
           {# ─────────────── PAST / FUTURE DAYS ─────────── #}
           {% else %}
             {% if entry is mapping %}
@@ -77,6 +78,31 @@
               –
             {% endif %}
           {% endif %}
+
+          <button
+            class="cell-edit-icon"
+            data-habit="{{ key }}"
+            data-label="{{ label }}"
+            data-duration="{{ entry.duration if entry else '' }}"
+            data-note="{{ entry.note if entry else '' }}"
+            data-date="{{ day|string }}"
+            data-default="{{ info.default_duration }}"
+            @click.prevent="
+              showModal = true;
+              const dur = $el.dataset.duration;
+              const note = $el.dataset.note;
+              const habit = $el.dataset.habit;
+              form = {
+                habit: habit,
+                label: $el.dataset.label,
+                duration: dur ? parseInt(dur) : (parseInt(localStorage.getItem(habit + '_duration')) || parseInt($el.dataset.default)),
+                note: note || localStorage.getItem(habit + '_note') || '',
+                date: $el.dataset.date,
+                entry_id: $el.dataset.date + '_' + habit
+              };
+            "
+            title="Edit"
+          >✏️</button>
         </td>
       {% endfor %}
     </tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,6 +76,7 @@
 
         <input type="hidden" name="habit" :value="form.habit">
         <input type="hidden" name="date"  :value="form.date">
+        <input type="hidden" name="entry_id" :value="form.entry_id">
 
         <label>Duration (minutes):</label>
         <input type="number" name="duration" x-model="form.duration" min="1" required>
@@ -105,7 +106,7 @@
         mood      : {{ mood or 3 }},
         moodSaved : false,
         showModal : false,
-        form      : { habit:'', label:'', duration:15, note:'', date:'' },
+        form      : { habit:'', label:'', duration:15, note:'', date:'', entry_id:'' },
         moodStats : JSON.parse(document.getElementById('mood-data').textContent),
 
         // toast state


### PR DESCRIPTION
## Summary
- add edit icon button to all habit grid cells
- track entry_id in the log modal form
- style hover edit icon
- test log update capability

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686897c430c0832d995a6ace6ba9688e