### PR TITLE
Add DB migration for user_id columns

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -90,6 +90,26 @@ class SQLiteBackend:
                 );
                 """
             )
+
+            # --- migration: add user_id columns if missing ---
+            cur.execute("PRAGMA table_info(habit_log)")
+            cols = [r[1] for r in cur.fetchall()]
+            if "user_id" not in cols:
+                cur.execute(
+                    "ALTER TABLE habit_log ADD COLUMN user_id INTEGER REFERENCES users(id)"
+                )
+                cur.execute(
+                    "UPDATE habit_log SET user_id = 1 WHERE user_id IS NULL"
+                )
+
+            cur.execute("PRAGMA table_info(mood_log)")
+            cols = [r[1] for r in cur.fetchall()]
+            if "user_id" not in cols:
+                cur.execute(
+                    "ALTER TABLE mood_log ADD COLUMN user_id INTEGER REFERENCES users(id)"
+                )
+                cur.execute("UPDATE mood_log SET user_id = 1 WHERE user_id IS NULL")
+
             self.conn.commit()
 
     def load_all(self):
@@ -194,6 +214,32 @@ class PostgresBackend(SQLiteBackend):
                 );
                 """
             )
+
+            # --- migration: add user_id columns if missing ---
+            cur.execute(
+                "SELECT column_name FROM information_schema.columns WHERE table_name='habit_log'"
+            )
+            cols = {r[0] for r in cur.fetchall()}
+            if "user_id" not in cols:
+                cur.execute(
+                    "ALTER TABLE habit_log ADD COLUMN user_id INTEGER REFERENCES users(id)"
+                )
+                cur.execute(
+                    "UPDATE habit_log SET user_id = 1 WHERE user_id IS NULL"
+                )
+
+            cur.execute(
+                "SELECT column_name FROM information_schema.columns WHERE table_name='mood_log'"
+            )
+            cols = {r[0] for r in cur.fetchall()}
+            if "user_id" not in cols:
+                cur.execute(
+                    "ALTER TABLE mood_log ADD COLUMN user_id INTEGER REFERENCES users(id)"
+                )
+                cur.execute(
+                    "UPDATE mood_log SET user_id = 1 WHERE user_id IS NULL"
+                )
+
             self.conn.commit()
 
     # Psycopg2 uses %s placeholders

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -20,6 +20,18 @@ def test_sqlite_mood_cycle(tmp_path):
     assert series[-1] == {"date": "2025-06-19", "score": 4}
 
 
+def test_user_id_columns_added(tmp_path):
+    """Migration adds user_id columns on init."""
+    db = SQLiteBackend(db_path=tmp_path / "schema.db")
+    cur = db.conn.cursor()
+    cur.execute("PRAGMA table_info(habit_log)")
+    cols = [r[1] for r in cur.fetchall()]
+    assert "user_id" in cols
+    cur.execute("PRAGMA table_info(mood_log)")
+    cols = [r[1] for r in cur.fetchall()]
+    assert "user_id" in cols
+
+
 def test_get_backend_postgres_failure(monkeypatch, caplog):
     """Fallback to SQLite if Postgres connection errors."""
     monkeypatch.setenv("DATABASE_URL", "postgres://bad")


### PR DESCRIPTION
## Summary
- add migration logic to add `user_id` column to `habit_log` and `mood_log`
- update existing rows to default to `user_id=1`
- test that migrations run when initializing `SQLiteBackend`

## Testing
- `source .venv/bin/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68689cd51490832db7e76150238646a9