### PR TITLE
Update docs for user accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Log habits & moods in seconds, jot AI-seeded journal entries, and review analyti
 git clone https://github.com/jake0lawrence/habit-track-cli.git
 cd habit-track-cli
 python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt  # installs Flask-Login & passlib too
 # ⬇️ Optional: enable AI journal prompts
 export OPENAI_API_KEY=sk-********************************
 # Choose config via APP_MODE (dev | prod)
@@ -61,12 +61,19 @@ python app.py   # auto-reload in dev mode
 
 Open [http://localhost:5000](http://localhost:5000) & start tracking.
 
+## 🔐 Sign Up & Log In
+
+The web UI now supports accounts. Head to `/signup` to create a user and then
+log in via `/login`. Passwords are hashed with **passlib[bcrypt]** and sessions
+are managed by **Flask-Login**. Existing data from older versions is migrated to
+the first account automatically.
+
 ---
 
 ## 🧪 Tests
 
 ```bash
-pip install -r requirements.txt  # install Flask, Typer & friends
+pip install -r requirements.txt  # install Flask, Flask-Login, passlib & friends
 pytest -q                     # unit tests
 npm ci && npx playwright test # E2E smoke
 ```
@@ -106,6 +113,7 @@ Need one-click? See `/docs/deploy-render.md`.
 | Layer             | Library                             |
 | ----------------- | ----------------------------------- |
 | Backend           | Flask 2.x                           |
+| Auth              | Flask-Login • passlib[bcrypt]        |
 | Frontend micro-JS | htmx 1.9 • Alpine 3.13              |
 | Charts            | Chart.js 4 (deferred import)        |
 | Styling           | Vanilla CSS (dark-mode class)       |
@@ -138,6 +146,8 @@ Happy tracking & journaling!
 
 * New **Journal** section in the feature table + env var note  
 * `/journal`, `/journal-history`, `/analytics` explained  
-* Toasts & Chart.js called out  
-* OpenAI API setup documented  
+* Toasts & Chart.js called out
+* OpenAI API setup documented
 * FAQ updated accordingly
+* Sign-up/login instructions & new auth dependencies
+* Database tables updated with user references

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,7 @@ htmx swaps only the relevant fragment on each page, so full reloads are rare.
 | Layer             | Technology                                | Why                    |
 | ----------------- | ----------------------------------------- | ---------------------- |
 | Backend           | **Flask 2**                               | Routing + Jinja        |
+| Auth              | **Flask‑Login**, **passlib[bcrypt]**      | Sessions & hashing     |
 | Front‑end runtime | **htmx 1.9** • **Alpine 3.13**            | 6 kB each, declarative |
 | Charts            | **Chart.js 4** (imported on `/analytics`) | Zero build step        |
 | Styling           | Vanilla CSS + dark‑mode class             |  Lightweight           |
@@ -59,9 +60,19 @@ htmx swaps only the relevant fragment on each page, so full reloads are rare.
 
 ## 4 · Data Model
 
-### 4.1 HabitLog table
+### 4.1 Users table
+
+| col | type | note |
+| --- | ---- | ---- |
+| `id` | SERIAL PK | |
+| `email` | TEXT UNIQUE | login id |
+| `password_hash` | TEXT | bcrypt hash |
+| `created_at` | TIMESTAMP | signup time |
+
+### 4.2 HabitLog table
 
 | col        | type      | note        |
+| `user_id`  | INT FK    | references users |
 | ---------- | --------- | ----------- |
 | `date`     | DATE PK₁  |             |
 | `habit`    | TEXT PK₂  |             |
@@ -69,25 +80,29 @@ htmx swaps only the relevant fragment on each page, so full reloads are rare.
 | `note`     | TEXT      | optional    |
 | `ts`       | TIMESTAMP | server time |
 
-### 4.2 Mood table
+### 4.3 Mood table
 
-| col     | type      |
-| ------- | --------- |
-| `date`  | DATE PK   |
-| `score` | INT (1‑5) |
-| `ts`    | TIMESTAMP |
+| col      | type      | note             |
+| -------- | --------- | ---------------- |
+| `user_id`| INT FK    | references users |
+| `date`   | DATE PK   |                  |
+| `score`  | INT (1‑5) |                  |
+| `ts`     | TIMESTAMP |                  |
 
-### 4.3 Journal table
+### 4.4 Journal table
 
 | col      | type      | note                     |
 | -------- | --------- | ------------------------ |
 | `id`     | SERIAL PK |                          |
+| `user_id` | INT FK    | references users |
 | `date`   | DATE      | one per day              |
 | `text`   | TEXT      | Markdown/string          |
 | `prompt` | TEXT      | GPT prompt shown to user |
 | `ts`     | TIMESTAMP | save time                |
 
 *(If using JSON, journals live under `journal:{date}` keys.)*
+
+Existing installations will create a default account at upgrade; all pre-account data is attached to this user (id 1).
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ flask>=2.3
 psycopg2-binary>=2.9
 openai>=1.0
 gunicorn>=23.0
+flask-login>=0.6
+passlib[bcrypt]>=1.7


### PR DESCRIPTION
## Summary
- document sign-up & log-in flow in README
- list Flask-Login and passlib in requirements
- highlight new auth stack in docs
- describe new Users table and migration note

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm ci`
- `npx playwright test` *(fails: browser install required)*

------
https://chatgpt.com/codex/tasks/task_e_68689cda9b88832dba59a7d83c996b15