### PR TITLE
Update e2e to login

### DIFF
--- a/e2e/save.spec.ts
+++ b/e2e/save.spec.ts
@@ -3,6 +3,11 @@ import { test, expect } from '@playwright/test';
 const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:5000';
 
 test('log habit end-to-end', async ({ page }) => {
+  // Login first so routes requiring authentication succeed
+  await page.goto(`${BASE_URL}/login`);
+  await page.locator('input[name="username"]').fill('playwright');
+  await page.getByRole('button', { name: 'Login' }).click();
+
   await page.goto(BASE_URL);
 
   // Open modal for the Meditation habit (key = med)


### PR DESCRIPTION
## Summary
- login before hitting the main page in save.spec

## Testing
- `pytest -q`
- `npx playwright install --with-deps`
- `gunicorn app:app --bind 127.0.0.1:5000 --workers 1 --daemon`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_6868a0918c34832db18ed7cdab55f6d4