### PR TITLE
Add argon2-cffi to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ openai>=1.0
 gunicorn>=23.0
 Flask-Login>=0.6
 Flask-WTF>=1.2
-argon2-cffi>=23.1
+argon2-cffi>=25.1.0


### PR DESCRIPTION
## Summary
- update requirements with the `argon2-cffi` package version 25.1.0

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: NameError: name 'FlaskForm' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686927ae2ff0832dad561b0aa78f271a