### PR TITLE
Add weekly navigation arrows

### DIFF
--- a/e2e/week_nav.spec.ts
+++ b/e2e/week_nav.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:5000';
+
+test('navigate between weeks', async ({ page }) => {
+  await page.goto(BASE_URL);
+  const initial = await page.locator('#habit-grid').getAttribute('data-week-label');
+  await page.locator('#week-nav button').first().click();
+  await expect(page.locator('#habit-grid')).not.toHaveAttribute('data-week-label', initial);
+  await page.locator('#week-nav button').nth(1).click();
+  await expect(page.locator('#habit-grid')).toHaveAttribute('data-week-label', initial);
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -121,6 +121,22 @@ body.dark .cell-done {
   background-color: #2e8b57;
 }
 
+/* Week navigation */
+.week-nav {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5em;
+  margin-top: 0.5em;
+}
+.week-nav button {
+  padding: 0 0.6em;
+  font-size: 1.2em;
+}
+.week-label {
+  font-weight: bold;
+}
+
 /* Entry Summary and Edit Button */
 .entry-summary {
   display: flex;

--- a/templates/_grid_wrapper.html
+++ b/templates/_grid_wrapper.html
@@ -1,0 +1,4 @@
+<div id="habit-grid" data-week-label="{{ week_label }}">
+  <div class="week-label">{{ week_label }}</div>
+  {{ grid|safe }}
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,21 @@
 
   <section>
     <h2>🗓️ Weekly Habit Grid</h2>
-    <div id="habit-grid">
+    <div id="week-nav" class="week-nav" x-data="{offset:0, weekLabel:'{{ week_label }}'}"
+         @htmx:afterSwap.window="if($event.detail.target.id==='habit-grid'){weekLabel=$event.detail.target.dataset.weekLabel}">
+      <button @click="offset -= 7"
+              hx-get="/grid?offset={{ '{{' }} offset {{ '}}' }}"
+              hx-target="#habit-grid"
+              hx-swap="outerHTML">‹</button>
+      <span x-text="weekLabel"></span>
+      <button @click="offset += 7"
+              :disabled="offset === 0"
+              hx-get="/grid?offset={{ '{{' }} offset {{ '}}' }}"
+              hx-target="#habit-grid"
+              hx-swap="outerHTML">›</button>
+    </div>
+    <div id="habit-grid" data-week-label="{{ week_label }}">
+      <div class="week-label">{{ week_label }}</div>
       {% include '_habit_row.html' %}
     </div>
   </section>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -246,3 +246,16 @@ def test_journal_history(tmp_path):
     finally:
         flask_app_module.JOURNAL_FILE = orig_journal
         restore(orig_data, orig_config)
+
+
+def test_grid_previous_week(tmp_path):
+    client, orig_data, orig_config = make_client(tmp_path)
+    try:
+        backend = flask_app_module.get_storage_backend()
+        start = flask_app_module.monday_of_current_week() - datetime.timedelta(days=7)
+        backend.save_habit(str(start), "med", 42, "note")
+        res = client.get("/grid?offset=-7")
+        assert res.status_code == 200
+        assert "42&nbsp;min" in res.get_data(as_text=True)
+    finally:
+        restore(orig_data, orig_config)


### PR DESCRIPTION
## Summary
- add helper functions for weekly offsets and labels
- implement `/grid` endpoint for HTMX updates
- include prev/next buttons and week label in the dashboard
- style week navigation and label
- test `/grid` offset logic and add Playwright test for week navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869430c5a3c832db92377ed13467e70